### PR TITLE
Fix account check for v2 runtimes

### DIFF
--- a/index.php
+++ b/index.php
@@ -106,7 +106,7 @@ function listLayers(string $version, string $region): array
 
     $layers = [];
     $accountId = '209497400698';
-    if ($version === 'v2' || strpos('2.', $version) === 0) {
+    if ($version === 'v2' || strpos($version, '2.') === 0) {
         $accountId = '534081306603';
     }
 


### PR DESCRIPTION
Fixes an issue where the version 2.0.1 of Bref was showing the v1 aws account number.

The needle & haystack were in the incorrect order, just switches them around.